### PR TITLE
SFAT-24 - inject guided-match db connection info.

### DIFF
--- a/terraform/modules/configs/deploy-all/main.tf
+++ b/terraform/modules/configs/deploy-all/main.tf
@@ -48,6 +48,18 @@ data "aws_ssm_parameter" "agreements_invoke_url" {
   name = "${lower(var.environment)}-agreements-service-root-url"
 }
 
+data "aws_ssm_parameter" "guided_match_db_endpoint" {
+  name = "${lower(var.environment)}-guided-match-db-endpoint"
+}
+
+data "aws_ssm_parameter" "guided_match_db_username" {
+  name = "${lower(var.environment)}-guided-match-db-master-username"
+}
+
+data "aws_ssm_parameter" "guided_match_db_password" {
+  name = "${lower(var.environment)}-guided-match-db-master-password"
+}
+
 module "ecs" {
   source      = "../../ecs"
   vpc_id      = data.aws_ssm_parameter.vpc_id.value
@@ -91,6 +103,9 @@ module "guided-match" {
   ecs_security_group_id        = module.ecs.ecs_security_group_id
   ecs_task_execution_arn       = module.ecs.ecs_task_execution_arn
   ecs_cluster_id               = module.ecs.ecs_cluster_id
+  guided_match_db_endpoint     = data.aws_ssm_parameter.guided_match_db_endpoint.value
+  guided_match_db_username     = data.aws_ssm_parameter.guided_match_db_username.value
+  guided_match_db_password     = data.aws_ssm_parameter.guided_match_db_password.value
 }
 
 module "api-deployment" {

--- a/terraform/modules/services/guided-match/ecs.tf
+++ b/terraform/modules/services/guided-match/ecs.tf
@@ -108,7 +108,7 @@ resource "aws_ecs_task_definition" "guided_match" {
           },
           {
           "name": "spring.datasource.url",
-          "value": "jdbc:postgresql://${var.guided_match_db_endpoint}:5432/guided-match"
+          "value": "jdbc:postgresql://${var.guided_match_db_endpoint}:5432/guided_match"
           }
         ]
       }

--- a/terraform/modules/services/guided-match/ecs.tf
+++ b/terraform/modules/services/guided-match/ecs.tf
@@ -96,7 +96,21 @@ resource "aws_ecs_task_definition" "guided_match" {
               "awslogs-region": "eu-west-2",
               "awslogs-stream-prefix": "fargate-guided-match"
           }
-        }
+        },
+        "environment" : [
+          {
+          "name": "spring.datasource.username",
+          "value": "${var.guided_match_db_username}"
+          },
+          {
+          "name": "spring.datasource.password",
+          "value": "${var.guided_match_db_password}"
+          },
+          {
+          "name": "spring.datasource.url",
+          "value": "jdbc:postgresql://${var.guided_match_db_endpoint}:5432/guided-match"
+          }
+        ]
       }
     ]
 DEFINITION

--- a/terraform/modules/services/guided-match/variables.tf
+++ b/terraform/modules/services/guided-match/variables.tf
@@ -50,3 +50,14 @@ variable "environment" {
   type = string
 }
 
+variable "guided_match_db_endpoint" {
+  type = string
+}
+
+variable "guided_match_db_username" {
+  type = string
+}
+
+variable "guided_match_db_password" {
+  type = string
+}


### PR DESCRIPTION
Note: using master credentials for now - need to change to service credentials when stable.

I have tried the same approach on Agreements service and deployed to SBX1 and it seems to works ok.