### PR TITLE
Bump versions of GM/DT svcs and remove lookup service from DT ECS task

### DIFF
--- a/terraform/modules/services/decision-tree/ecs.tf
+++ b/terraform/modules/services/decision-tree/ecs.tf
@@ -77,7 +77,7 @@ resource "aws_ecs_task_definition" "decision_tree" {
     [
     {
         "name": "SCALE-EU2-${upper(var.environment)}-APP-ECS_TaskDef_DecisionTree",
-        "image": "${module.globals.env_accounts["mgmt"]}.dkr.ecr.eu-west-2.amazonaws.com/scale/decision-tree-service:d3e5bfb-candidate",
+        "image": "${module.globals.env_accounts["mgmt"]}.dkr.ecr.eu-west-2.amazonaws.com/scale/decision-tree-service:00ef1a1-snapshot",
         "requires_compatibilities": "FARGATE",
         "cpu": 256,
         "memory": 512,
@@ -99,25 +99,8 @@ resource "aws_ecs_task_definition" "decision_tree" {
         }
       },
       {
-          "name": "SCALE-EU2-${upper(var.environment)}-APP-ECS_TaskDef_LookupService",
-          "image": "${module.globals.env_accounts["mgmt"]}.dkr.ecr.eu-west-2.amazonaws.com/scale/lookup-service:5b5b654-candidate",
-          "requires_compatibilities": "FARGATE",
-          "cpu": 256,
-          "memory": 512,
-          "essential": true,
-          "networkMode": "awsvpc",
-          "logConfiguration": {
-            "logDriver": "awslogs",
-            "options": {
-                "awslogs-group": "${aws_cloudwatch_log_group.fargate_scale.name}",
-                "awslogs-region": "eu-west-2",
-                "awslogs-stream-prefix": "fargate-lookup-service"
-            }
-          }
-      },
-      {
           "name": "SCALE-EU2-${upper(var.environment)}-APP-ECS_TaskDef_DecisionTreeDB",
-          "image": "${module.globals.env_accounts["mgmt"]}.dkr.ecr.eu-west-2.amazonaws.com/scale/decision-tree-db:2a80cc3-candidate",
+          "image": "${module.globals.env_accounts["mgmt"]}.dkr.ecr.eu-west-2.amazonaws.com/scale/decision-tree-db:46d1abd-candidate",
           "requires_compatibilities": "FARGATE",
           "cpu": 512,
           "memory": 1024,

--- a/terraform/modules/services/guided-match/ecs.tf
+++ b/terraform/modules/services/guided-match/ecs.tf
@@ -77,7 +77,7 @@ resource "aws_ecs_task_definition" "guided_match" {
     [
       {
         "name": "SCALE-EU2-${upper(var.environment)}-APP-ECS_TaskDef_GuidedMatch",
-        "image": "${module.globals.env_accounts["mgmt"]}.dkr.ecr.eu-west-2.amazonaws.com/scale/guided-match-service:76b17f3-candidate",
+        "image": "${module.globals.env_accounts["mgmt"]}.dkr.ecr.eu-west-2.amazonaws.com/scale/guided-match-service:9f258bb-snapshot",
         "requires_compatibilities": "FARGATE",
         "cpu": 256,
         "memory": 512,


### PR DESCRIPTION
Will update the versions here for GM and DT service from `snapshot` to `candidate` once they're both merged - PRs to follow.. this is reflective of the current deployment configuration on SBX2 👍 