### PR TITLE
SFAT-191 - NFT

### DIFF
--- a/terraform/environments/nft/main.tf
+++ b/terraform/environments/nft/main.tf
@@ -1,0 +1,41 @@
+#########################################################
+# Environment: NFT (Non Functional Testing)
+#
+# Deploy SCALE resources
+#########################################################
+terraform {
+  backend "s3" {
+    bucket         = "scale-terraform-state"
+    key            = "ccs-scale-infra-services-fat-nft"
+    region         = "eu-west-2"
+    dynamodb_table = "scale_terraform_state_lock"
+    encrypt        = true
+  }
+}
+
+provider "aws" {
+  profile = "default"
+  region  = "eu-west-2"
+}
+
+locals {
+  environment = "NFT"
+}
+
+data "aws_ssm_parameter" "aws_account_id" {
+  name = "account-id-${lower(local.environment)}"
+}
+
+module "deploy" {
+  source                       = "../../modules/configs/deploy-all"
+  aws_account_id               = data.aws_ssm_parameter.aws_account_id.value
+  environment                  = local.environment
+  decision_tree_cpu            = 2048
+  decision_tree_memory         = 4096
+  decision_tree_service_cpu    = 1024
+  decision_tree_service_memory = 2048
+  decision_tree_db_cpu         = 1024
+  decision_tree_db_memory      = 2048
+  guided_match_cpu             = 1024
+  guided_match_memory          = 2048
+}

--- a/terraform/modules/configs/deploy-all/main.tf
+++ b/terraform/modules/configs/deploy-all/main.tf
@@ -86,6 +86,12 @@ module "decision-tree" {
   ecs_security_group_id        = module.ecs.ecs_security_group_id
   ecs_task_execution_arn       = module.ecs.ecs_task_execution_arn
   ecs_cluster_id               = module.ecs.ecs_cluster_id
+  decision_tree_cpu            = var.decision_tree_cpu
+  decision_tree_memory         = var.decision_tree_memory
+  decision_tree_service_cpu    = var.decision_tree_service_cpu
+  decision_tree_service_memory = var.decision_tree_service_memory
+  decision_tree_db_cpu         = var.decision_tree_db_cpu
+  decision_tree_db_memory      = var.decision_tree_db_memory
 }
 
 module "guided-match" {
@@ -106,6 +112,8 @@ module "guided-match" {
   guided_match_db_endpoint     = data.aws_ssm_parameter.guided_match_db_endpoint.value
   guided_match_db_username     = data.aws_ssm_parameter.guided_match_db_username.value
   guided_match_db_password     = data.aws_ssm_parameter.guided_match_db_password.value
+  guided_match_cpu             = var.guided_match_cpu
+  guided_match_memory          = var.guided_match_memory
 }
 
 module "api-deployment" {

--- a/terraform/modules/configs/deploy-all/variables.tf
+++ b/terraform/modules/configs/deploy-all/variables.tf
@@ -10,3 +10,43 @@ variable "ecr_image_id_fat_buyer_ui" {
   type = string
   default = "85a5ed2-candidate"
 }
+
+variable "decision_tree_cpu" {
+  type = number
+  default = 1024
+}
+
+variable "decision_tree_memory" {
+  type = number
+  default = 2048
+}
+
+variable "decision_tree_service_cpu" {
+  type = number
+  default = 256
+}
+
+variable "decision_tree_service_memory" {
+  type = number
+  default = 512
+}
+
+variable "decision_tree_db_cpu" {
+  type = number
+  default = 512
+}
+
+variable "decision_tree_db_memory" {
+  type = number
+  default = 1024
+}
+
+variable "guided_match_cpu" {
+  type = number
+  default = 256
+}
+
+variable "guided_match_memory" {
+  type = number
+  default = 512
+}

--- a/terraform/modules/services/decision-tree/ecs.tf
+++ b/terraform/modules/services/decision-tree/ecs.tf
@@ -69,8 +69,8 @@ resource "aws_ecs_task_definition" "decision_tree" {
   family                   = "decision-tree"
   requires_compatibilities = ["FARGATE"]
   network_mode             = "awsvpc"
-  cpu                      = 1024
-  memory                   = 2048
+  cpu                      = var.decision_tree_cpu
+  memory                   = var.decision_tree_memory
   execution_role_arn       = var.ecs_task_execution_arn
 
   container_definitions = <<DEFINITION
@@ -79,8 +79,8 @@ resource "aws_ecs_task_definition" "decision_tree" {
         "name": "SCALE-EU2-${upper(var.environment)}-APP-ECS_TaskDef_DecisionTree",
         "image": "${module.globals.env_accounts["mgmt"]}.dkr.ecr.eu-west-2.amazonaws.com/scale/decision-tree-service:d985aaa-candidate",
         "requires_compatibilities": "FARGATE",
-        "cpu": 256,
-        "memory": 512,
+        "cpu": ${var.decision_tree_service_cpu},
+        "memory": ${var.decision_tree_service_memory},
         "essential": true,
         "networkMode": "awsvpc",
         "portMappings": [
@@ -102,8 +102,8 @@ resource "aws_ecs_task_definition" "decision_tree" {
           "name": "SCALE-EU2-${upper(var.environment)}-APP-ECS_TaskDef_DecisionTreeDB",
           "image": "${module.globals.env_accounts["mgmt"]}.dkr.ecr.eu-west-2.amazonaws.com/scale/decision-tree-db:46d1abd-candidate",
           "requires_compatibilities": "FARGATE",
-          "cpu": 512,
-          "memory": 1024,
+          "cpu": ${var.decision_tree_db_cpu},
+          "memory": ${var.decision_tree_db_memory},
           "essential": true,
           "networkMode": "awsvpc",
           "portMappings": [

--- a/terraform/modules/services/decision-tree/variables.tf
+++ b/terraform/modules/services/decision-tree/variables.tf
@@ -50,3 +50,26 @@ variable "environment" {
   type = string
 }
 
+variable "decision_tree_cpu" {
+  type = number
+}
+
+variable "decision_tree_memory" {
+  type = number
+}
+
+variable "decision_tree_service_cpu" {
+  type = number
+}
+
+variable "decision_tree_service_memory" {
+  type = number
+}
+
+variable "decision_tree_db_cpu" {
+  type = number
+}
+
+variable "decision_tree_db_memory" {
+  type = number
+}

--- a/terraform/modules/services/guided-match/ecs.tf
+++ b/terraform/modules/services/guided-match/ecs.tf
@@ -69,8 +69,8 @@ resource "aws_ecs_task_definition" "guided_match" {
   family                   = "guided-match"
   requires_compatibilities = ["FARGATE"]
   network_mode             = "awsvpc"
-  cpu                      = 512
-  memory                   = 1024
+  cpu                      = var.guided_match_cpu
+  memory                   = var.guided_match_memory
   execution_role_arn       = var.ecs_task_execution_arn
 
   container_definitions = <<DEFINITION
@@ -79,8 +79,8 @@ resource "aws_ecs_task_definition" "guided_match" {
         "name": "SCALE-EU2-${upper(var.environment)}-APP-ECS_TaskDef_GuidedMatch",
         "image": "${module.globals.env_accounts["mgmt"]}.dkr.ecr.eu-west-2.amazonaws.com/scale/guided-match-service:76b17f3-candidate",
         "requires_compatibilities": "FARGATE",
-        "cpu": 256,
-        "memory": 512,
+        "cpu": ${var.guided_match_cpu},
+        "memory": ${var.guided_match_memory},
         "essential": true,
         "networkMode": "awsvpc",
         "portMappings": [

--- a/terraform/modules/services/guided-match/variables.tf
+++ b/terraform/modules/services/guided-match/variables.tf
@@ -61,3 +61,11 @@ variable "guided_match_db_username" {
 variable "guided_match_db_password" {
   type = string
 }
+
+variable "guided_match_cpu" {
+  type = number
+}
+
+variable "guided_match_memory" {
+  type = number
+}


### PR DESCRIPTION
This (and `ccs-scale-infra-services-shared`) are the ones that need a bit more thought - in relation to cpu & memory requirements at container/task level. Som's infra document doesn't go to that level of detail. Decision Tree is the trickiest - as it has 2 containers per task. I had a quick scan of documentation - but it's a bit late - and need to revisit tomorrow - numbers may need some fine tuning.