### PR TITLE
Feature/sfat 153 move decision tree db ecs to db subnet

### DIFF
--- a/terraform/environments/nft/main.tf
+++ b/terraform/environments/nft/main.tf
@@ -30,8 +30,6 @@ module "deploy" {
   source                       = "../../modules/configs/deploy-all"
   aws_account_id               = data.aws_ssm_parameter.aws_account_id.value
   environment                  = local.environment
-  decision_tree_cpu            = 2048
-  decision_tree_memory         = 4096
   decision_tree_service_cpu    = 1024
   decision_tree_service_memory = 2048
   decision_tree_db_cpu         = 1024

--- a/terraform/modules/configs/deploy-all/variables.tf
+++ b/terraform/modules/configs/deploy-all/variables.tf
@@ -11,42 +11,32 @@ variable "ecr_image_id_fat_buyer_ui" {
   default = "8d37d91-candidate"
 }
 
-variable "decision_tree_cpu" {
-  type = number
-  default = 1024
-}
-
-variable "decision_tree_memory" {
-  type = number
-  default = 2048
-}
-
 variable "decision_tree_service_cpu" {
-  type = number
-  default = 256
-}
-
-variable "decision_tree_service_memory" {
-  type = number
+  type    = number
   default = 512
 }
 
+variable "decision_tree_service_memory" {
+  type    = number
+  default = 1024
+}
+
 variable "decision_tree_db_cpu" {
-  type = number
+  type    = number
   default = 512
 }
 
 variable "decision_tree_db_memory" {
-  type = number
+  type    = number
   default = 1024
 }
 
 variable "guided_match_cpu" {
-  type = number
+  type    = number
   default = 256
 }
 
 variable "guided_match_memory" {
-  type = number
+  type    = number
   default = 512
 }

--- a/terraform/modules/ecs/main.tf
+++ b/terraform/modules/ecs/main.tf
@@ -58,6 +58,15 @@ resource "aws_security_group" "allow_http" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
+  ingress {
+    from_port = 7687
+    to_port   = 7687
+    protocol  = "tcp"
+    # Please restrict your ingress to only necessary IPs and ports.
+    # Opening to 0.0.0.0/0 can lead to security vulnerabilities.
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
   egress {
     from_port = 0
     to_port   = 65535
@@ -117,7 +126,8 @@ resource "aws_iam_policy" "ecs_task_execution" {
         "ecr:GetDownloadUrlForLayer",
         "ecr:BatchGetImage",
         "logs:CreateLogStream",
-        "logs:PutLogEvents"
+        "logs:PutLogEvents",
+        "ssm:GetParameters"
       ],
       "Resource": "*"
     }

--- a/terraform/modules/services/decision-tree-db/ecs.tf
+++ b/terraform/modules/services/decision-tree-db/ecs.tf
@@ -1,0 +1,139 @@
+
+#########################################################
+# Service: Decision Tree DB ECS
+#
+# ECS Fargate Service and Task Definitions.
+#########################################################
+module "globals" {
+  source = "../../globals"
+}
+
+#######################################################################
+# NLB target group & listener for traffic on port 7687 (DecisionTree DB)
+#######################################################################
+resource "aws_lb_target_group" "target_group_7687" {
+  name        = "SCALE-EU2-${upper(var.environment)}-VPC-TG-DTreeDB"
+  port        = 7687
+  protocol    = "TCP"
+  target_type = "ip"
+  vpc_id      = var.vpc_id
+
+  stickiness {
+    type    = "lb_cookie"
+    enabled = false
+  }
+
+  tags = {
+    Project     = module.globals.project_name
+    Environment = upper(var.environment)
+    Cost_Code   = module.globals.project_cost_code
+    AppType     = "LOADBALANCER"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_lb_listener" "port_7687" {
+  load_balancer_arn = var.lb_private_db_arn
+  port              = "7687"
+  protocol          = "TCP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.target_group_7687.arn
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_ecs_service" "decision_tree_db" {
+  name             = "SCALE-EU2-${upper(var.environment)}-DB-ECS_Service_DecisionTreeDB"
+  cluster          = var.ecs_cluster_id
+  task_definition  = aws_ecs_task_definition.decision_tree_db.arn
+  launch_type      = "FARGATE"
+  platform_version = "LATEST"
+  desired_count    = 1
+
+  network_configuration {
+    security_groups  = [var.ecs_security_group_id]
+    subnets          = var.private_db_subnet_ids
+    assign_public_ip = false
+  }
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.target_group_7687.arn
+    container_name   = "SCALE-EU2-${upper(var.environment)}-DB-ECS_TaskDef_DecisionTreeDB"
+    container_port   = 7687
+  }
+}
+
+resource "aws_ecs_task_definition" "decision_tree_db" {
+  family                   = "decision-tree-db"
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = var.decision_tree_db_cpu
+  memory                   = var.decision_tree_db_memory
+  execution_role_arn       = var.ecs_task_execution_arn
+
+  container_definitions = <<DEFINITION
+    [
+      {
+          "name": "SCALE-EU2-${upper(var.environment)}-DB-ECS_TaskDef_DecisionTreeDB",
+          "image": "${module.globals.env_accounts["mgmt"]}.dkr.ecr.eu-west-2.amazonaws.com/scale/decision-tree-db:fbc84d9-candidate",
+          "requires_compatibilities": "FARGATE",
+          "cpu": ${var.decision_tree_db_cpu},
+          "memory": ${var.decision_tree_db_memory},
+          "essential": true,
+          "networkMode": "awsvpc",
+          "portMappings": [
+              {
+              "containerPort": 7687,
+              "hostPort": 7687
+              }
+          ],
+          "logConfiguration": {
+            "logDriver": "awslogs",
+            "options": {
+                "awslogs-group": "${aws_cloudwatch_log_group.fargate_scale.name}",
+                "awslogs-region": "eu-west-2",
+                "awslogs-stream-prefix": "fargate-neo4j"
+            }
+          },
+          "secrets": [
+              {
+                  "name": "DB_ADMIN_USERNAME",
+                  "valueFrom": "${var.decision_tree_db_admin_username_arn}"
+              },
+              {
+                  "name": "DB_ADMIN_PASSWORD",
+                  "valueFrom": "${var.decision_tree_db_admin_password_arn}"
+              },
+              {
+                  "name": "DB_SERVICE_ACCOUNT_USERNAME",
+                  "valueFrom": "${var.decision_tree_db_service_account_username_arn}"
+              },
+              {
+                  "name": "DB_SERVICE_ACCOUNT_PASSWORD",
+                  "valueFrom": "${var.decision_tree_db_service_account_password_arn}"
+              }
+          ]
+        }
+    ]
+DEFINITION
+
+  tags = {
+    Project     = module.globals.project_name
+    Environment = upper(var.environment)
+    Cost_Code   = module.globals.project_cost_code
+    AppType     = "ECS"
+  }
+}
+
+resource "aws_cloudwatch_log_group" "fargate_scale" {
+  name_prefix       = "/fargate/service/scale/decision-tree-db"
+  retention_in_days = 7
+}

--- a/terraform/modules/services/decision-tree-db/variables.tf
+++ b/terraform/modules/services/decision-tree-db/variables.tf
@@ -1,0 +1,51 @@
+variable "vpc_id" {
+  type = string
+}
+
+variable "private_db_subnet_ids" {
+  type = list(string)
+}
+
+variable "ecs_cluster_id" {
+  type = string
+}
+
+variable "ecs_security_group_id" {
+  type = string
+}
+
+variable "ecs_task_execution_arn" {
+  type = string
+}
+
+variable "lb_private_db_arn" {
+  type = string
+}
+
+variable "environment" {
+  type = string
+}
+
+variable "decision_tree_db_cpu" {
+  type = number
+}
+
+variable "decision_tree_db_memory" {
+  type = number
+}
+
+variable "decision_tree_db_admin_username_arn" {
+  type = string
+}
+
+variable "decision_tree_db_admin_password_arn" {
+  type = string
+}
+
+variable "decision_tree_db_service_account_username_arn" {
+  type = string
+}
+
+variable "decision_tree_db_service_account_password_arn" {
+  type = string
+}

--- a/terraform/modules/services/decision-tree/variables.tf
+++ b/terraform/modules/services/decision-tree/variables.tf
@@ -46,16 +46,12 @@ variable "lb_private_dns" {
   type = string
 }
 
-variable "environment" {
+variable "lb_private_db_dns" {
   type = string
 }
 
-variable "decision_tree_cpu" {
-  type = number
-}
-
-variable "decision_tree_memory" {
-  type = number
+variable "environment" {
+  type = string
 }
 
 variable "decision_tree_service_cpu" {
@@ -66,10 +62,10 @@ variable "decision_tree_service_memory" {
   type = number
 }
 
-variable "decision_tree_db_cpu" {
-  type = number
+variable "decision_tree_db_service_account_username_arn" {
+  type = string
 }
 
-variable "decision_tree_db_memory" {
-  type = number
+variable "decision_tree_db_service_account_password_arn" {
+  type = string
 }

--- a/terraform/modules/services/fat-buyer-ui/variables.tf
+++ b/terraform/modules/services/fat-buyer-ui/variables.tf
@@ -2,27 +2,11 @@ variable "ecr_image_id_fat_buyer_ui" {
   type = string
 }
 
-variable "scale_rest_api_id" {
-  type = string
-}
-
-variable "scale_rest_api_execution_arn" {
-  type = string
-}
-
-variable "parent_resource_id" {
-  type = string
-}
-
 variable "vpc_id" {
   type = string
 }
 
 variable "private_app_subnet_ids" {
-  type = list(string)
-}
-
-variable "private_db_subnet_ids" {
   type = list(string)
 }
 
@@ -38,19 +22,7 @@ variable "ecs_task_execution_arn" {
   type = string
 }
 
-variable "vpc_link_id" {
-  type = string
-}
-
 variable "lb_public_arn" {
-  type = string
-}
-
-variable "lb_private_arn" {
-  type = string
-}
-
-variable "lb_private_dns" {
   type = string
 }
 


### PR DESCRIPTION
This moves the DT DB ECS service to the DB subnets behind the new load balancer, with creds for admin and service account users passed in via container secrets. Left the SG config alone as discussed. Instructions as to which new SSM parameter must be provisioned up front are in [Confluence](https://www.google.com/url?q=https://crowncommercialservice.atlassian.net/wiki/spaces/SCALE/pages/411336743/Provision%2BFaT%2BServices&sa=D&source=hangouts&ust=1592946839639000&usg=AFQjCNF3GVCGFy7liy7M8L6Vq4bw910IQw).