### PR TITLE
SFAT-123 - added Usage Plan and API Keys, inject into BuyerUI env vars

### DIFF
--- a/terraform/modules/configs/deploy-all/main.tf
+++ b/terraform/modules/configs/deploy-all/main.tf
@@ -84,8 +84,13 @@ data "aws_ssm_parameter" "decision_tree_db_service_account_password" {
   name = "${lower(var.environment)}-decision-tree-db-service-account-password"
 }
 
+
 data "aws_ssm_parameter" "cidr_block_vpc" {
   name = "${lower(var.environment)}-cidr-block-vpc"
+}
+
+data "aws_ssm_parameter" "shared_api_key" {
+  name = "${lower(var.environment)}-fat-buyer-ui-shared-api-key"
 }
 
 module "ecs" {
@@ -165,6 +170,8 @@ module "api-deployment" {
   source            = "../../services/api-deployment"
   environment       = var.environment
   scale_rest_api_id = module.api.scale_rest_api_id
+  api_rate_limit    = var.api_rate_limit
+  api_burst_limit   = var.api_burst_limit
 
   // Simulate depends_on:
   decision_tree_api_gateway_integration = module.decision-tree.decision_tree_api_gateway_integration
@@ -184,4 +191,6 @@ module "fat-buyer-ui" {
   ecr_image_id_fat_buyer_ui = var.ecr_image_id_fat_buyer_ui
   agreements_invoke_url     = data.aws_ssm_parameter.agreements_invoke_url.value
   api_invoke_url            = module.api-deployment.api_invoke_url
+  shared_api_key            = data.aws_ssm_parameter.shared_api_key.value
+  fat_api_key               = module.api-deployment.fat_api_key
 }

--- a/terraform/modules/configs/deploy-all/variables.tf
+++ b/terraform/modules/configs/deploy-all/variables.tf
@@ -7,7 +7,7 @@ variable "environment" {
 }
 
 variable "ecr_image_id_fat_buyer_ui" {
-  type = string
+  type    = string
   default = "0c90781-candidate"
 }
 
@@ -39,4 +39,14 @@ variable "guided_match_cpu" {
 variable "guided_match_memory" {
   type    = number
   default = 512
+}
+
+variable "api_rate_limit" {
+  type    = number
+  default = 10000
+}
+
+variable "api_burst_limit" {
+  type    = number
+  default = 5000
 }

--- a/terraform/modules/configs/deploy-all/variables.tf
+++ b/terraform/modules/configs/deploy-all/variables.tf
@@ -8,7 +8,7 @@ variable "environment" {
 
 variable "ecr_image_id_fat_buyer_ui" {
   type    = string
-  default = "0c90781-candidate"
+  default = "6f4ed9b-candidate"
 }
 
 variable "decision_tree_service_cpu" {

--- a/terraform/modules/services/api-deployment/main.tf
+++ b/terraform/modules/services/api-deployment/main.tf
@@ -1,7 +1,12 @@
-variable "scale_rest_api_id" {
-  type = string
-}
+#########################################################
+# Service: API Deployments
+#
+# Creates Usage Plan/API Keys and deployment.
+#########################################################
 
+#########################################################
+# Deployment
+#########################################################
 resource "aws_api_gateway_deployment" "fat" {
   description = "Deployed at ${timestamp()}"
   rest_api_id = var.scale_rest_api_id
@@ -42,4 +47,56 @@ resource "aws_api_gateway_method_settings" "scale" {
 resource "aws_cloudwatch_log_group" "api_gw_execution" {
   name              = "API-Gateway-Execution-Logs_${var.scale_rest_api_id}/${lower(var.environment)}-fat"
   retention_in_days = 7
+}
+
+
+#########################################################
+# Usage Plans
+#########################################################
+resource "aws_api_gateway_usage_plan" "default" {
+  name        = "default-usage-plan"
+  description = "Default Usage Plan"
+
+  api_stages {
+    api_id = var.scale_rest_api_id
+    stage  = aws_api_gateway_stage.fat.stage_name
+  }
+
+  throttle_settings {
+    rate_limit  = var.api_rate_limit
+    burst_limit = var.api_burst_limit
+  }
+}
+
+#########################################################
+# API Keys
+#########################################################
+resource "aws_api_gateway_api_key" "fat_buyer_ui" {
+  name = "FaT Buyer UI API Key (FaT)"
+}
+
+resource "aws_api_gateway_api_key" "fat_testers" {
+  name = "FaT Testers API Key (FaT)"
+}
+
+resource "aws_api_gateway_api_key" "fat_developers" {
+  name = "FaT Developers API Key (FaT)"
+}
+
+resource "aws_api_gateway_usage_plan_key" "fat_buyer_ui" {
+  key_id        = aws_api_gateway_api_key.fat_buyer_ui.id
+  key_type      = "API_KEY"
+  usage_plan_id = aws_api_gateway_usage_plan.default.id
+}
+
+resource "aws_api_gateway_usage_plan_key" "fat_testers" {
+  key_id        = aws_api_gateway_api_key.fat_testers.id
+  key_type      = "API_KEY"
+  usage_plan_id = aws_api_gateway_usage_plan.default.id
+}
+
+resource "aws_api_gateway_usage_plan_key" "fat_developers" {
+  key_id        = aws_api_gateway_api_key.fat_developers.id
+  key_type      = "API_KEY"
+  usage_plan_id = aws_api_gateway_usage_plan.default.id
 }

--- a/terraform/modules/services/api-deployment/outputs.tf
+++ b/terraform/modules/services/api-deployment/outputs.tf
@@ -2,3 +2,7 @@
 output "api_invoke_url" {
   value = aws_api_gateway_stage.fat.invoke_url
 }
+
+output "fat_api_key" {
+  value = aws_api_gateway_api_key.fat_buyer_ui.value
+}

--- a/terraform/modules/services/api-deployment/variables.tf
+++ b/terraform/modules/services/api-deployment/variables.tf
@@ -2,10 +2,22 @@ variable "environment" {
   type = string
 }
 
+variable "scale_rest_api_id" {
+  type = string
+}
+
 variable "decision_tree_api_gateway_integration" {
   type = string
 }
 
 variable "guided_match_api_gateway_integration" {
   type = string
+}
+
+variable "api_rate_limit" {
+  type = number
+}
+
+variable "api_burst_limit" {
+  type = number
 }

--- a/terraform/modules/services/decision-tree/api.tf
+++ b/terraform/modules/services/decision-tree/api.tf
@@ -26,10 +26,11 @@ module "decision_tree_cors" {
 }
 
 resource "aws_api_gateway_method" "decision_tree_proxy" {
-  rest_api_id   = var.scale_rest_api_id
-  resource_id   = aws_api_gateway_resource.decision_tree_proxy.id
-  http_method   = "ANY"
-  authorization = "NONE"
+  rest_api_id      = var.scale_rest_api_id
+  resource_id      = aws_api_gateway_resource.decision_tree_proxy.id
+  http_method      = "ANY"
+  authorization    = "NONE"
+  api_key_required = true
 
   request_parameters = {
     "method.request.path.proxy" = false

--- a/terraform/modules/services/fat-buyer-ui/ecs.tf
+++ b/terraform/modules/services/fat-buyer-ui/ecs.tf
@@ -111,6 +111,14 @@ resource "aws_ecs_task_definition" "fat_buyer_ui" {
           {
           "name": "GUIDED_MATCH_SERVICE_ROOT_URL",
           "value": "${var.api_invoke_url}"
+          },
+          {
+          "name": "AGREEMENTS_SERVICE_API_KEY",
+          "value": "${var.shared_api_key}"
+          },
+          {
+          "name": "GUIDED_MATCH_SERVICE_API_KEY",
+          "value": "${var.fat_api_key}"
           }
         ]
       }

--- a/terraform/modules/services/fat-buyer-ui/variables.tf
+++ b/terraform/modules/services/fat-buyer-ui/variables.tf
@@ -37,3 +37,11 @@ variable "api_invoke_url" {
 variable "agreements_invoke_url" {
   type = string
 }
+
+variable "fat_api_key" {
+  type = string
+}
+
+variable "shared_api_key" {
+  type = string
+}

--- a/terraform/modules/services/guided-match/api.tf
+++ b/terraform/modules/services/guided-match/api.tf
@@ -26,10 +26,11 @@ module "guided_match_cors" {
 }
 
 resource "aws_api_gateway_method" "guided_match_proxy" {
-  rest_api_id   = var.scale_rest_api_id
-  resource_id   = aws_api_gateway_resource.guided_match_proxy.id
-  http_method   = "ANY"
-  authorization = "NONE"
+  rest_api_id      = var.scale_rest_api_id
+  resource_id      = aws_api_gateway_resource.guided_match_proxy.id
+  http_method      = "ANY"
+  authorization    = "NONE"
+  api_key_required = true
 
   request_parameters = {
     "method.request.path.proxy" = false


### PR DESCRIPTION
The other part of the previous Code review (which is still unmerged and has some minor tweaks since review - https://github.com/Crown-Commercial-Service/ccs-scale-infra-services-shared/pull/7)

This PR will generate Usage Plan/Keys for FaT API. It will also inject the API Keys as new environment variables into BuyerUI ECS task.