### PR TITLE
Extend the ECS service desired count to cover all AZs

### DIFF
--- a/terraform/modules/services/decision-tree-db/ecs.tf
+++ b/terraform/modules/services/decision-tree-db/ecs.tf
@@ -56,7 +56,7 @@ resource "aws_ecs_service" "decision_tree_db" {
   task_definition  = aws_ecs_task_definition.decision_tree_db.arn
   launch_type      = "FARGATE"
   platform_version = "LATEST"
-  desired_count    = 1
+  desired_count    = length(var.private_db_subnet_ids)
 
   network_configuration {
     security_groups  = [var.ecs_security_group_id]

--- a/terraform/modules/services/decision-tree/ecs.tf
+++ b/terraform/modules/services/decision-tree/ecs.tf
@@ -58,7 +58,7 @@ resource "aws_ecs_service" "decision_tree" {
   task_definition  = aws_ecs_task_definition.decision_tree.arn
   launch_type      = "FARGATE"
   platform_version = "LATEST"
-  desired_count    = 1
+  desired_count    = length(var.private_app_subnet_ids)
 
   network_configuration {
     security_groups  = [var.ecs_security_group_id]

--- a/terraform/modules/services/guided-match/ecs.tf
+++ b/terraform/modules/services/guided-match/ecs.tf
@@ -50,7 +50,7 @@ resource "aws_ecs_service" "guided_match" {
   task_definition  = aws_ecs_task_definition.guided_match.arn
   launch_type      = "FARGATE"
   platform_version = "LATEST"
-  desired_count    = 1
+  desired_count    = length(var.private_app_subnet_ids)
 
   network_configuration {
     security_groups  = [var.ecs_security_group_id]


### PR DESCRIPTION
Part Two - another nice easy one.. as discussed 👍 

Should find when you apply this on SBX1 (after https://github.com/Crown-Commercial-Service/ccs-scale-infrastructure/pull/12 has been applied) that you get an extra task in the second DB AZ.