### PR TITLE
DT version bump - fix dropped DB conns

### DIFF
--- a/terraform/modules/services/decision-tree/ecs.tf
+++ b/terraform/modules/services/decision-tree/ecs.tf
@@ -85,7 +85,7 @@ resource "aws_ecs_task_definition" "decision_tree" {
     [
     {
         "name": "SCALE-EU2-${upper(var.environment)}-APP-ECS_TaskDef_DecisionTreeSvc",
-        "image": "${module.globals.env_accounts["mgmt"]}.dkr.ecr.eu-west-2.amazonaws.com/scale/decision-tree-service:e846d61-candidate",
+        "image": "${module.globals.env_accounts["mgmt"]}.dkr.ecr.eu-west-2.amazonaws.com/scale/decision-tree-service:d3f5824-snapshot",
         "requires_compatibilities": "FARGATE",
         "cpu": ${var.decision_tree_service_cpu},
         "memory": ${var.decision_tree_service_memory},


### PR DESCRIPTION
Just a placeholder - needs updating with a candidate once built from https://github.com/Crown-Commercial-Service/ccs-scale-decision-tree-service/pull/19