### PR TITLE
Version bump DT DB and UI

### DIFF
--- a/terraform/modules/configs/deploy-all/variables.tf
+++ b/terraform/modules/configs/deploy-all/variables.tf
@@ -8,7 +8,7 @@ variable "environment" {
 
 variable "ecr_image_id_fat_buyer_ui" {
   type    = string
-  default = "78deb29-candidate"
+  default = "49e32bf-candidate"
 }
 
 variable "decision_tree_service_cpu" {

--- a/terraform/modules/services/decision-tree-db/ecs.tf
+++ b/terraform/modules/services/decision-tree-db/ecs.tf
@@ -83,7 +83,7 @@ resource "aws_ecs_task_definition" "decision_tree_db" {
     [
       {
           "name": "SCALE-EU2-${upper(var.environment)}-DB-ECS_TaskDef_DecisionTreeDB",
-          "image": "${module.globals.env_accounts["mgmt"]}.dkr.ecr.eu-west-2.amazonaws.com/scale/decision-tree-db:4059783-candidate",
+          "image": "${module.globals.env_accounts["mgmt"]}.dkr.ecr.eu-west-2.amazonaws.com/scale/decision-tree-db:c6d539f-candidate",
           "requires_compatibilities": "FARGATE",
           "cpu": ${var.decision_tree_db_cpu},
           "memory": ${var.decision_tree_db_memory},


### PR DESCRIPTION
Deploys the new UI version which picks up the injected CMS root URL and a fix to the Decision Tree service for SFC-437