### PR TITLE
SFC-800 - added connection params to speed up DB failover

### DIFF
--- a/terraform/modules/services/guided-match/ecs.tf
+++ b/terraform/modules/services/guided-match/ecs.tf
@@ -110,7 +110,7 @@ resource "aws_ecs_task_definition" "guided_match" {
         "environment" : [
           {
           "name": "spring.datasource.url",
-          "value": "jdbc:postgresql://${var.guided_match_db_endpoint}:5432/guided_match"
+          "value": "jdbc:postgresql://${var.guided_match_db_endpoint}:5432/guided_match?connectTimeout=2&cancelSignalTimeout=2&socketTimeout=60&targetServerType=master"
           },
           {
           "name": "external.decision-tree-service.url",


### PR DESCRIPTION
This is taking some of the recommendations from https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraPostgreSQL.BestPractices.html

I could replicate the problem consistently on SBX1
* Select the Writer instance and 'Failover'
* All connections would switch to the Reader instance, and stay there
* The Buyer UI would then show API errors (constantly)

This change seemed to fix that. I did see one error briefly (which would be multiplied under load), but it quickly worked again. I think this is because setting the targetServerType to `master` forces it to use a Writer instance. So there will be a few seconds where errors occur.

There are some other suggestions in the document that I had lined up also - but as this seems to fix it I'll keep the change to a minimal.

