### PR TITLE
SFAT-308 - task count alarm was using wrong statistic, and not dynamic

### DIFF
--- a/terraform/modules/configs/deploy-all/main.tf
+++ b/terraform/modules/configs/deploy-all/main.tf
@@ -210,25 +210,28 @@ module "fat-buyer-ui" {
 
 
 module "cloudwatch-alarms-guided-match" {
-  source           = "../../cw-alarms"
-  environment      = var.environment
-  ecs_cluster_name = module.ecs.ecs_cluster_name
-  ecs_service_name = module.guided-match.ecs_service_name
-  service_name     = "guided-match"
+  source                  = "../../cw-alarms"
+  environment             = var.environment
+  ecs_cluster_name        = module.ecs.ecs_cluster_name
+  ecs_service_name        = module.guided-match.ecs_service_name
+  service_name            = "guided-match"
+  ecs_expected_task_count = length(split(",", data.aws_ssm_parameter.private_app_subnet_ids.value))
 }
 
 module "cloudwatch-alarms-decision-tree" {
-  source           = "../../cw-alarms"
-  environment      = var.environment
-  ecs_cluster_name = module.ecs.ecs_cluster_name
-  ecs_service_name = module.decision-tree.ecs_service_name
-  service_name     = "decision-tree"
+  source                  = "../../cw-alarms"
+  environment             = var.environment
+  ecs_cluster_name        = module.ecs.ecs_cluster_name
+  ecs_service_name        = module.decision-tree.ecs_service_name
+  service_name            = "decision-tree"
+  ecs_expected_task_count = length(split(",", data.aws_ssm_parameter.private_app_subnet_ids.value))
 }
 
 module "cloudwatch-alarms-fat-buyer-ui" {
-  source           = "../../cw-alarms"
-  environment      = var.environment
-  ecs_cluster_name = module.ecs.ecs_cluster_name
-  ecs_service_name = module.fat-buyer-ui.ecs_service_name
-  service_name     = "fat-buyer-ui"
+  source                  = "../../cw-alarms"
+  environment             = var.environment
+  ecs_cluster_name        = module.ecs.ecs_cluster_name
+  ecs_service_name        = module.fat-buyer-ui.ecs_service_name
+  service_name            = "fat-buyer-ui"
+  ecs_expected_task_count = length(split(",", data.aws_ssm_parameter.private_app_subnet_ids.value))
 }

--- a/terraform/modules/cw-alarms/main.tf
+++ b/terraform/modules/cw-alarms/main.tf
@@ -53,8 +53,8 @@ resource "aws_cloudwatch_metric_alarm" "task" {
   metric_name               = "MemoryUtilization"
   namespace                 = "AWS/ECS"
   period                    = "60"
-  statistic                 = "Average"
-  threshold                 = "3"
+  statistic                 = "SampleCount"
+  threshold                 = var.ecs_expected_task_count
   alarm_description         = "This metric monitors task removals"
   insufficient_data_actions = []
   alarm_actions             = [aws_sns_topic.alarms.arn]

--- a/terraform/modules/cw-alarms/variables.tf
+++ b/terraform/modules/cw-alarms/variables.tf
@@ -13,3 +13,7 @@ variable ecs_service_name {
 variable service_name {
   type = string
 }
+
+variable "ecs_expected_task_count" {
+  type = string
+}


### PR DESCRIPTION
Noticed was using Average instead of SampleCount to determine if alarm should trigger if task number dipped (would never trigger in this case)

(Also was not using a dynamic threshold - unlike shared-services - so fixed)