### PR TITLE
SSL configuration for ALB Listener

### DIFF
--- a/terraform/modules/configs/deploy-all/main.tf
+++ b/terraform/modules/configs/deploy-all/main.tf
@@ -32,10 +32,6 @@ data "aws_ssm_parameter" "vpc_link_id" {
   name = "${lower(var.environment)}-vpc-link-id"
 }
 
-data "aws_ssm_parameter" "lb_public_arn" {
-  name = "${lower(var.environment)}-lb-public-arn"
-}
-
 data "aws_ssm_parameter" "lb_public_alb_arn" {
   name = "${lower(var.environment)}-lb-public-alb-arn"
 }
@@ -192,7 +188,6 @@ module "fat-buyer-ui" {
   environment               = var.environment
   vpc_id                    = data.aws_ssm_parameter.vpc_id.value
   private_app_subnet_ids    = split(",", data.aws_ssm_parameter.private_app_subnet_ids.value)
-  lb_public_arn             = data.aws_ssm_parameter.lb_public_arn.value
   lb_public_alb_arn         = data.aws_ssm_parameter.lb_public_alb_arn.value
   ecs_security_group_id     = module.ecs.ecs_security_group_id
   ecs_task_execution_arn    = module.ecs.ecs_task_execution_arn

--- a/terraform/modules/services/fat-buyer-ui/ecs.tf
+++ b/terraform/modules/services/fat-buyer-ui/ecs.tf
@@ -21,9 +21,8 @@ data "aws_acm_certificate" "alb" {
 # NLB target group & listener for traffic on port 9030 (Agreements API)
 #######################################################################
 resource "aws_lb_target_group" "target_group_9030" {
-  name = "SCALE-EU2-${upper(var.environment)}-VPC-FaTBuyerUI"
-  port = 9030
-  # protocol    = "TCP"
+  name        = "SCALE-EU2-${upper(var.environment)}-VPC-FaTBuyerUI"
+  port        = 9030
   protocol    = "HTTP"
   target_type = "ip"
   vpc_id      = var.vpc_id

--- a/terraform/modules/services/fat-buyer-ui/variables.tf
+++ b/terraform/modules/services/fat-buyer-ui/variables.tf
@@ -22,10 +22,6 @@ variable "ecs_task_execution_arn" {
   type = string
 }
 
-variable "lb_public_arn" {
-  type = string
-}
-
 variable "lb_public_alb_arn" {
   type = string
 }


### PR DESCRIPTION
Locks down the ALB - UI listener to HTTPS on port 443 with tighter SSL config