### PR TITLE
Feature/sfat 314 standardise docker vars

### DIFF
--- a/terraform/modules/configs/deploy-all/main.tf
+++ b/terraform/modules/configs/deploy-all/main.tf
@@ -129,6 +129,7 @@ module "decision-tree" {
   decision_tree_service_memory                  = var.decision_tree_service_memory
   decision_tree_db_service_account_username_arn = data.aws_ssm_parameter.decision_tree_db_service_account_username.arn
   decision_tree_db_service_account_password_arn = data.aws_ssm_parameter.decision_tree_db_service_account_password.arn
+  ecr_image_id_decision_tree                    = var.ecr_image_id_decision_tree
 }
 
 module "decision-tree-db" {
@@ -146,6 +147,7 @@ module "decision-tree-db" {
   decision_tree_db_admin_password_arn           = data.aws_ssm_parameter.decision_tree_db_admin_password.arn
   decision_tree_db_service_account_username_arn = data.aws_ssm_parameter.decision_tree_db_service_account_username.arn
   decision_tree_db_service_account_password_arn = data.aws_ssm_parameter.decision_tree_db_service_account_password.arn
+  ecr_image_id_decision_tree_db                 = var.ecr_image_id_decision_tree_db
 }
 
 module "guided-match" {
@@ -168,6 +170,7 @@ module "guided-match" {
   guided_match_db_password_arn = data.aws_ssm_parameter.guided_match_db_password.arn
   guided_match_cpu             = var.guided_match_cpu
   guided_match_memory          = var.guided_match_memory
+  ecr_image_id_guided_match    = var.ecr_image_id_guided_match
 }
 
 module "api-deployment" {

--- a/terraform/modules/configs/deploy-all/variables.tf
+++ b/terraform/modules/configs/deploy-all/variables.tf
@@ -11,6 +11,21 @@ variable "ecr_image_id_fat_buyer_ui" {
   default = "911fc6e-candidate"
 }
 
+variable "ecr_image_id_guided_match" {
+  type    = string
+  default = "66f3a6a-candidate"
+}
+
+variable "ecr_image_id_decision_tree" {
+  type    = string
+  default = "fa32e3f-candidate"
+}
+
+variable "ecr_image_id_decision_tree_db" {
+  type    = string
+  default = "74edfc7-candidate"
+}
+
 variable "decision_tree_service_cpu" {
   type    = number
   default = 512

--- a/terraform/modules/services/decision-tree-db/ecs.tf
+++ b/terraform/modules/services/decision-tree-db/ecs.tf
@@ -83,7 +83,7 @@ resource "aws_ecs_task_definition" "decision_tree_db" {
     [
       {
           "name": "SCALE-EU2-${upper(var.environment)}-DB-ECS_TaskDef_DecisionTreeDB",
-          "image": "${module.globals.env_accounts["mgmt"]}.dkr.ecr.eu-west-2.amazonaws.com/scale/decision-tree-db:070ec58-candidate",
+          "image": "${module.globals.env_accounts["mgmt"]}.dkr.ecr.eu-west-2.amazonaws.com/scale/decision-tree-db:${var.ecr_image_id_decision_tree_db}",
           "requires_compatibilities": "FARGATE",
           "cpu": ${var.decision_tree_db_cpu},
           "memory": ${var.decision_tree_db_memory},

--- a/terraform/modules/services/decision-tree-db/variables.tf
+++ b/terraform/modules/services/decision-tree-db/variables.tf
@@ -49,3 +49,7 @@ variable "decision_tree_db_service_account_username_arn" {
 variable "decision_tree_db_service_account_password_arn" {
   type = string
 }
+
+variable "ecr_image_id_decision_tree_db" {
+  type = string
+}

--- a/terraform/modules/services/decision-tree/ecs.tf
+++ b/terraform/modules/services/decision-tree/ecs.tf
@@ -85,7 +85,7 @@ resource "aws_ecs_task_definition" "decision_tree" {
     [
     {
         "name": "SCALE-EU2-${upper(var.environment)}-APP-ECS_TaskDef_DecisionTreeSvc",
-        "image": "${module.globals.env_accounts["mgmt"]}.dkr.ecr.eu-west-2.amazonaws.com/scale/decision-tree-service:fa32e3f-candidate",
+        "image": "${module.globals.env_accounts["mgmt"]}.dkr.ecr.eu-west-2.amazonaws.com/scale/decision-tree-service:${var.ecr_image_id_decision_tree}",
         "requires_compatibilities": "FARGATE",
         "cpu": ${var.decision_tree_service_cpu},
         "memory": ${var.decision_tree_service_memory},

--- a/terraform/modules/services/decision-tree/variables.tf
+++ b/terraform/modules/services/decision-tree/variables.tf
@@ -69,3 +69,7 @@ variable "decision_tree_db_service_account_username_arn" {
 variable "decision_tree_db_service_account_password_arn" {
   type = string
 }
+
+variable "ecr_image_id_decision_tree" {
+  type    = string
+}

--- a/terraform/modules/services/guided-match/ecs.tf
+++ b/terraform/modules/services/guided-match/ecs.tf
@@ -77,7 +77,7 @@ resource "aws_ecs_task_definition" "guided_match" {
     [
       {
         "name": "SCALE-EU2-${upper(var.environment)}-APP-ECS_TaskDef_GuidedMatch",
-        "image": "${module.globals.env_accounts["mgmt"]}.dkr.ecr.eu-west-2.amazonaws.com/scale/guided-match-service:66f3a6a-candidate",
+        "image": "${module.globals.env_accounts["mgmt"]}.dkr.ecr.eu-west-2.amazonaws.com/scale/guided-match-service:${var.ecr_image_id_guided_match}",
         "requires_compatibilities": "FARGATE",
         "cpu": ${var.guided_match_cpu},
         "memory": ${var.guided_match_memory},

--- a/terraform/modules/services/guided-match/variables.tf
+++ b/terraform/modules/services/guided-match/variables.tf
@@ -69,3 +69,7 @@ variable "guided_match_cpu" {
 variable "guided_match_memory" {
   type = number
 }
+
+variable "ecr_image_id_guided_match" {
+  type = string
+}


### PR DESCRIPTION
Just thinking ahead to handover to devs - thought it would be easier to explain/document if the place to update the docker image versions was consistent across services/projects - i.e. `configs/deploy-all/main.tf` (and having it here allows for environment specific overrides - if that's ever needed)