### PR TITLE
Feature/sfat 317 log retention

### DIFF
--- a/terraform/environments/nft/main.tf
+++ b/terraform/environments/nft/main.tf
@@ -39,4 +39,6 @@ module "deploy" {
   buyer_ui_cpu                 = 1024
   buyer_ui_memory              = 2048
   webcms_root_url              = "https://webuat-cms.crowncommercial.gov.uk/" # Pre-prod
+  api_gw_log_retention_in_days = 30
+  ecs_log_retention_in_days    = 30
 }

--- a/terraform/environments/ppd/main.tf
+++ b/terraform/environments/ppd/main.tf
@@ -39,4 +39,6 @@ module "deploy" {
   buyer_ui_cpu                 = 1024
   buyer_ui_memory              = 2048
   webcms_root_url              = "https://webuat-cms.crowncommercial.gov.uk/" # Pre-prod
+  api_gw_log_retention_in_days = 30
+  ecs_log_retention_in_days    = 30
 }

--- a/terraform/environments/prd/main.tf
+++ b/terraform/environments/prd/main.tf
@@ -39,4 +39,6 @@ module "deploy" {
   buyer_ui_cpu                 = 1024
   buyer_ui_memory              = 2048
   webcms_root_url              = "https://webprod-cms.crowncommercial.gov.uk/" # Prod
+  api_gw_log_retention_in_days = 30
+  ecs_log_retention_in_days    = 30
 }

--- a/terraform/modules/configs/deploy-all/main.tf
+++ b/terraform/modules/configs/deploy-all/main.tf
@@ -130,6 +130,7 @@ module "decision-tree" {
   decision_tree_db_service_account_username_arn = data.aws_ssm_parameter.decision_tree_db_service_account_username.arn
   decision_tree_db_service_account_password_arn = data.aws_ssm_parameter.decision_tree_db_service_account_password.arn
   ecr_image_id_decision_tree                    = var.ecr_image_id_decision_tree
+  ecs_log_retention_in_days                     = var.ecs_log_retention_in_days
 }
 
 module "decision-tree-db" {
@@ -148,6 +149,7 @@ module "decision-tree-db" {
   decision_tree_db_service_account_username_arn = data.aws_ssm_parameter.decision_tree_db_service_account_username.arn
   decision_tree_db_service_account_password_arn = data.aws_ssm_parameter.decision_tree_db_service_account_password.arn
   ecr_image_id_decision_tree_db                 = var.ecr_image_id_decision_tree_db
+  ecs_log_retention_in_days                     = var.ecs_log_retention_in_days
 }
 
 module "guided-match" {
@@ -171,14 +173,16 @@ module "guided-match" {
   guided_match_cpu             = var.guided_match_cpu
   guided_match_memory          = var.guided_match_memory
   ecr_image_id_guided_match    = var.ecr_image_id_guided_match
+  ecs_log_retention_in_days    = var.ecs_log_retention_in_days
 }
 
 module "api-deployment" {
-  source            = "../../services/api-deployment"
-  environment       = var.environment
-  scale_rest_api_id = module.api.scale_rest_api_id
-  api_rate_limit    = var.api_rate_limit
-  api_burst_limit   = var.api_burst_limit
+  source                       = "../../services/api-deployment"
+  environment                  = var.environment
+  scale_rest_api_id            = module.api.scale_rest_api_id
+  api_rate_limit               = var.api_rate_limit
+  api_burst_limit              = var.api_burst_limit
+  api_gw_log_retention_in_days = var.api_gw_log_retention_in_days
 
   // Simulate depends_on:
   decision_tree_api_gateway_integration = module.decision-tree.decision_tree_api_gateway_integration
@@ -204,6 +208,7 @@ module "fat-buyer-ui" {
   buyer_ui_cpu              = var.buyer_ui_cpu
   buyer_ui_memory           = var.buyer_ui_memory
   cloudfront_id             = data.aws_ssm_parameter.cloudfront_id.value
+  ecs_log_retention_in_days = var.ecs_log_retention_in_days
 }
 
 

--- a/terraform/modules/configs/deploy-all/variables.tf
+++ b/terraform/modules/configs/deploy-all/variables.tf
@@ -23,7 +23,7 @@ variable "ecr_image_id_decision_tree" {
 
 variable "ecr_image_id_decision_tree_db" {
   type    = string
-  default = "d39cc53-snapshot"
+  default = "90820aa-candidate"
 }
 
 variable "decision_tree_service_cpu" {

--- a/terraform/modules/configs/deploy-all/variables.tf
+++ b/terraform/modules/configs/deploy-all/variables.tf
@@ -23,7 +23,7 @@ variable "ecr_image_id_decision_tree" {
 
 variable "ecr_image_id_decision_tree_db" {
   type    = string
-  default = "8a8c302-candidate"
+  default = "d39cc53-snapshot"
 }
 
 variable "decision_tree_service_cpu" {
@@ -81,4 +81,14 @@ variable "webcms_root_url" {
 
   # Default to the DEV CMS
   default = "https://webdev-cms.crowncommercial.gov.uk"
+}
+
+variable "api_gw_log_retention_in_days" {
+  type    = number
+  default = 7
+}
+
+variable "ecs_log_retention_in_days" {
+  type    = number
+  default = 7
 }

--- a/terraform/modules/services/api-deployment/main.tf
+++ b/terraform/modules/services/api-deployment/main.tf
@@ -46,9 +46,8 @@ resource "aws_api_gateway_method_settings" "scale" {
 
 resource "aws_cloudwatch_log_group" "api_gw_execution" {
   name              = "API-Gateway-Execution-Logs_${var.scale_rest_api_id}/${lower(var.environment)}-fat"
-  retention_in_days = 7
+  retention_in_days = var.api_gw_log_retention_in_days
 }
-
 
 #########################################################
 # Usage Plans

--- a/terraform/modules/services/api-deployment/variables.tf
+++ b/terraform/modules/services/api-deployment/variables.tf
@@ -21,3 +21,7 @@ variable "api_rate_limit" {
 variable "api_burst_limit" {
   type = number
 }
+
+variable "api_gw_log_retention_in_days" {
+  type = number
+}

--- a/terraform/modules/services/decision-tree-db/ecs.tf
+++ b/terraform/modules/services/decision-tree-db/ecs.tf
@@ -135,5 +135,5 @@ DEFINITION
 
 resource "aws_cloudwatch_log_group" "fargate_scale" {
   name_prefix       = "/fargate/service/scale/decision-tree-db"
-  retention_in_days = 7
+  retention_in_days = var.ecs_log_retention_in_days
 }

--- a/terraform/modules/services/decision-tree-db/variables.tf
+++ b/terraform/modules/services/decision-tree-db/variables.tf
@@ -53,3 +53,7 @@ variable "decision_tree_db_service_account_password_arn" {
 variable "ecr_image_id_decision_tree_db" {
   type = string
 }
+
+variable "ecs_log_retention_in_days" {
+  type = number
+}

--- a/terraform/modules/services/decision-tree/ecs.tf
+++ b/terraform/modules/services/decision-tree/ecs.tf
@@ -136,5 +136,5 @@ DEFINITION
 
 resource "aws_cloudwatch_log_group" "fargate_scale" {
   name_prefix       = "/fargate/service/scale/decision-tree-service"
-  retention_in_days = 7
+  retention_in_days = var.ecs_log_retention_in_days
 }

--- a/terraform/modules/services/decision-tree/variables.tf
+++ b/terraform/modules/services/decision-tree/variables.tf
@@ -73,3 +73,7 @@ variable "decision_tree_db_service_account_password_arn" {
 variable "ecr_image_id_decision_tree" {
   type    = string
 }
+
+variable "ecs_log_retention_in_days" {
+  type = number
+}

--- a/terraform/modules/services/fat-buyer-ui/ecs.tf
+++ b/terraform/modules/services/fat-buyer-ui/ecs.tf
@@ -175,5 +175,5 @@ DEFINITION
 
 resource "aws_cloudwatch_log_group" "fargate_scale" {
   name_prefix       = "/fargate/service/scale/fat-buyer-ui"
-  retention_in_days = 7
+  retention_in_days = var.ecs_log_retention_in_days
 }

--- a/terraform/modules/services/fat-buyer-ui/variables.tf
+++ b/terraform/modules/services/fat-buyer-ui/variables.tf
@@ -61,3 +61,7 @@ variable "buyer_ui_memory" {
 variable "cloudfront_id" {
   type = string
 }
+
+variable "ecs_log_retention_in_days" {
+  type = number
+}

--- a/terraform/modules/services/guided-match/ecs.tf
+++ b/terraform/modules/services/guided-match/ecs.tf
@@ -131,5 +131,5 @@ DEFINITION
 
 resource "aws_cloudwatch_log_group" "fargate_scale" {
   name_prefix       = "/fargate/service/scale/guided-match"
-  retention_in_days = 7
+  retention_in_days = var.ecs_log_retention_in_days
 }

--- a/terraform/modules/services/guided-match/variables.tf
+++ b/terraform/modules/services/guided-match/variables.tf
@@ -73,3 +73,7 @@ variable "guided_match_memory" {
 variable "ecr_image_id_guided_match" {
   type = string
 }
+
+variable "ecs_log_retention_in_days" {
+  type = number
+}


### PR DESCRIPTION
Made ECS & API log retention configurable and set to 30 days for NFT/PPD/PRD (which aligns it with CloudTrail log retention)