### PR TITLE
Bump FaT Buyer UI to 6a36677-candidate-r1.1 (dockerfile)

### DIFF
--- a/terraform/modules/configs/deploy-all/variables.tf
+++ b/terraform/modules/configs/deploy-all/variables.tf
@@ -8,7 +8,7 @@ variable "environment" {
 
 variable "ecr_image_id_fat_buyer_ui" {
   type    = string
-  default = "79cd995-candidate"
+  default = "6a36677-candidate-r1.1"
 }
 
 variable "ecr_image_id_guided_match" {


### PR DESCRIPTION
Rebased the `release/1.1` branch on develop to ensure no divergence.