### PR TITLE
Bump FaT UI version to b04a059-candidate-release-1-1

### DIFF
--- a/terraform/modules/configs/deploy-all/variables.tf
+++ b/terraform/modules/configs/deploy-all/variables.tf
@@ -8,7 +8,7 @@ variable "environment" {
 
 variable "ecr_image_id_fat_buyer_ui" {
   type    = string
-  default = "eab4f6c-candidate-release-1-1"
+  default = "b04a059-candidate-release-1-1"
 }
 
 variable "ecr_image_id_guided_match" {


### PR DESCRIPTION
As requested - this appeared to be the latest R1.1 candidate build in ECR.