### PR TITLE
Remove redundant NLB stickiness blocks from TGs

### DIFF
--- a/terraform/modules/services/decision-tree-db/ecs.tf
+++ b/terraform/modules/services/decision-tree-db/ecs.tf
@@ -18,11 +18,6 @@ resource "aws_lb_target_group" "target_group_7687" {
   target_type = "ip"
   vpc_id      = var.vpc_id
 
-  stickiness {
-    type    = "lb_cookie"
-    enabled = false
-  }
-
   tags = {
     Project     = module.globals.project_name
     Environment = upper(var.environment)

--- a/terraform/modules/services/decision-tree/ecs.tf
+++ b/terraform/modules/services/decision-tree/ecs.tf
@@ -18,11 +18,6 @@ resource "aws_lb_target_group" "target_group_9000" {
   target_type = "ip"
   vpc_id      = var.vpc_id
 
-  stickiness {
-    type    = "lb_cookie"
-    enabled = false
-  }
-
   tags = {
     Project     = module.globals.project_name
     Environment = upper(var.environment)

--- a/terraform/modules/services/guided-match/ecs.tf
+++ b/terraform/modules/services/guided-match/ecs.tf
@@ -18,11 +18,6 @@ resource "aws_lb_target_group" "target_group_9020" {
   target_type = "ip"
   vpc_id      = var.vpc_id
 
-  stickiness {
-    type    = "lb_cookie"
-    enabled = false
-  }
-
   tags = {
     Project     = module.globals.project_name
     Environment = upper(var.environment)


### PR DESCRIPTION
Pipeline failing - not convinced this will make it pass as it still fails locally too - AWS Provider issue in TF as seen before..