### PR TITLE
Tighten ECS SG egress to VPC/ports as far as poss

### DIFF
--- a/terraform/modules/api/main.tf
+++ b/terraform/modules/api/main.tf
@@ -1,7 +1,7 @@
 #########################################################
 # Infrastructure: API
 #
-# Deploy API Gateway account level resources. 
+# Deploy API Gateway account level resources.
 # API Deployments are done later, after services.
 #########################################################
 module "globals" {
@@ -68,6 +68,10 @@ EOF
 resource "aws_api_gateway_rest_api" "scale" {
   name        = "SCALE:EU2:${upper(var.environment)}:API:FAT"
   description = "SCALE API Gateway"
+
+  endpoint_configuration {
+    types = ["EDGE"]
+  }
 
   tags = {
     Project     = module.globals.project_name

--- a/terraform/modules/ecs/main.tf
+++ b/terraform/modules/ecs/main.tf
@@ -7,6 +7,16 @@ module "globals" {
   source = "../globals"
 }
 
+data "aws_vpc_endpoint" "ecr" {
+  vpc_id       = var.vpc_id
+  service_name = "com.amazonaws.eu-west-2.ecr.dkr"
+}
+
+data "aws_vpc_endpoint" "s3" {
+  vpc_id       = var.vpc_id
+  service_name = "com.amazonaws.eu-west-2.s3"
+}
+
 resource "aws_ecs_cluster" "scale" {
   name = "SCALE-EU2-${upper(var.environment)}-APP-ECS_FAT"
 
@@ -38,7 +48,7 @@ resource "aws_security_group" "allow_http" {
     protocol    = "tcp"
     cidr_blocks = [var.cidr_block_vpc]
   }
-  
+
   ingress {
     from_port   = 9020
     to_port     = 9020
@@ -61,10 +71,38 @@ resource "aws_security_group" "allow_http" {
   }
 
   egress {
-    from_port   = 0
-    to_port     = 65535
+    from_port   = 7687
+    to_port     = 7687
     protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = [var.cidr_block_vpc]
+  }
+
+  egress {
+    from_port   = 5432
+    to_port     = 5432
+    protocol    = "tcp"
+    cidr_blocks = [var.cidr_block_vpc]
+  }
+
+  egress {
+    from_port   = 9000
+    to_port     = 9000
+    protocol    = "tcp"
+    cidr_blocks = [var.cidr_block_vpc]
+  }
+
+  # Allow traffic to/from ECR and S3 endpoints via VPC link
+  # https://7thzero.com/blog/limiting-outbound-egress-traffic-while-using-aws-fargate-and-ecr
+  egress {
+    from_port       = 443
+    to_port         = 443
+    protocol        = "tcp"
+    security_groups = data.aws_vpc_endpoint.ecr.security_group_ids # SG ID of VPC ECR endpoint
+    prefix_list_ids = [data.aws_vpc_endpoint.s3.prefix_list_id]    # Prefix list ID of S3 endpoint
+
+    # TODO: SINF-67 - DO NOT REMOVE '0.0.0.0/0' yet
+    # (Fixed IP range for connection to CCS Web CMS not yet available)
+    cidr_blocks = [var.cidr_block_vpc, "0.0.0.0/0"]
   }
 
   tags = {


### PR DESCRIPTION
Round 2.. again I think you'll need the targeted destroy on the REST API first.  Once this has been run, do an apply off the develop branch of shared-infra and once it's destroyed the API Gateway VPC endpoint it should all be working (is on SBX2 anyway..)