### PR TITLE
Restrict access to FaT REST API to VPC, NAT and external ranges

### DIFF
--- a/terraform/modules/api/main.tf
+++ b/terraform/modules/api/main.tf
@@ -65,6 +65,27 @@ EOF
 }
 
 # API gateway, top-level..
+data "aws_iam_policy_document" "scale" {
+  source_json = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Principal": "*",
+            "Action": "execute-api:Invoke",
+            "Resource": "*",
+            "Condition" : {
+                "IpAddress": {
+                    "aws:SourceIp": ${jsonencode(var.cidr_blocks_allowed_external_api_gateway)}
+                }
+            }
+        }
+    ]
+}
+EOF
+}
+
 resource "aws_api_gateway_rest_api" "scale" {
   name        = "SCALE:EU2:${upper(var.environment)}:API:FAT"
   description = "SCALE API Gateway"
@@ -73,11 +94,24 @@ resource "aws_api_gateway_rest_api" "scale" {
     types = ["EDGE"]
   }
 
+  policy = data.aws_iam_policy_document.scale.json
+
   tags = {
     Project     = module.globals.project_name
     Environment = upper(var.environment)
     Cost_Code   = module.globals.project_cost_code
     AppType     = "APIGATEWAY"
+  }
+}
+
+# Default Access Denied gateway response exposes info about the API so replace it.
+resource "aws_api_gateway_gateway_response" "access_denied" {
+  rest_api_id   = aws_api_gateway_rest_api.scale.id
+  status_code   = "403"
+  response_type = "ACCESS_DENIED"
+
+  response_templates = {
+    "application/json" = jsonencode({ "message" = "Access denied" })
   }
 }
 

--- a/terraform/modules/api/outputs.tf
+++ b/terraform/modules/api/outputs.tf
@@ -9,3 +9,7 @@ output "scale_rest_api_execution_arn" {
 output "parent_resource_id" {
   value = aws_api_gateway_resource.scale.id
 }
+
+output "scale_rest_api_policy_json" {
+  value = data.aws_iam_policy_document.scale.json
+}

--- a/terraform/modules/api/variables.tf
+++ b/terraform/modules/api/variables.tf
@@ -1,3 +1,7 @@
 variable "environment" {
   type = string
 }
+
+variable "cidr_blocks_allowed_external_api_gateway" {
+  type = list
+}

--- a/terraform/modules/services/api-deployment/main.tf
+++ b/terraform/modules/services/api-deployment/main.tf
@@ -17,6 +17,10 @@ resource "aws_api_gateway_deployment" "fat" {
     var.guided_match_api_gateway_integration
   ]
 
+  triggers = {
+    redeployment = sha1(var.scale_rest_api_policy_json)
+  }
+
   lifecycle {
     create_before_destroy = true
   }

--- a/terraform/modules/services/api-deployment/variables.tf
+++ b/terraform/modules/services/api-deployment/variables.tf
@@ -25,3 +25,7 @@ variable "api_burst_limit" {
 variable "api_gw_log_retention_in_days" {
   type = number
 }
+
+variable "scale_rest_api_policy_json" {
+  type = string
+}


### PR DESCRIPTION
Part 2 - this uses the external ranges defined in bootstrap and combines them with the VPC range and crucially the NAT EIP public IPs to ensure the UI still works.  If this and https://github.com/Crown-Commercial-Service/ccs-scale-bootstrap/pull/85 look ok I'll prepare an equivalent one for the shared services.  Once it's all on TST we'll need to ask the web team to re-point CCS web dev at the TST env and check the landing page still works (the purple box).